### PR TITLE
Introduce Docker builds to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,65 @@
+name: Build and Push Docker Image
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA to build the image from'
+        required: false
+        default: '${{ github.sha }}'
+      image_tag:
+        description: 'Desired Docker image tag'
+        required: false
+        default: 'latest'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_sha }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ inputs.image_tag }}
+            ghcr.io/${{ github.repository }}:${{ env.SHORT_SHA }}
+          # the ##*/ grabs the "arm64" from "linux/arm64"
+          build-args: |
+            ARCH=${{ matrix.platform##*/ }}


### PR DESCRIPTION
This may save others some time by using Actions resources instead of local resources to build. The hope is that then you'd simply navigate to a directory with your `HW2.qmd` file and run:

```bash
docker run -it --rm \
    -p 3838:3838 \
    -v "$(pwd):/app" \
    ghcr.io/kfcampbell/quarto-docker-sandbox:latest \
    quarto preview /app/HW2.qmd --host 0.0.0.0 --port 3838
```